### PR TITLE
Removed circular imports

### DIFF
--- a/rest_framework_auth0/authentication.py
+++ b/rest_framework_auth0/authentication.py
@@ -37,7 +37,7 @@ class Auth0JSONWebTokenAuthentication(JSONWebTokenAuthentication, RemoteUserBack
         """
         user, jwt_value = self.authenticate(request)
         if jwt_value is None:
-            return False
+            return None
         # jwt_decode_handler errors are managed on parent's authenticate method
         payload = jwt_decode_handler(jwt_value)
         return payload

--- a/rest_framework_auth0/authentication.py
+++ b/rest_framework_auth0/authentication.py
@@ -30,6 +30,19 @@ class Auth0JSONWebTokenAuthentication(JSONWebTokenAuthentication, RemoteUserBack
     # Create a User object if not already in the database?
     create_unknown_user = True
 
+
+    def get_payload(self, request):
+        """
+        Returns the request's payload
+        """
+        user, jwt_value = self.authenticate(request)
+        if jwt_value is None:
+            return False
+        # jwt_decode_handler errors are managed on parent's authenticate method
+        payload = jwt_decode_handler(jwt_value)
+        return payload
+
+
     def authenticate_credentials(self, payload):
         """
         Returns an active user that matches the payload's user id and email.

--- a/rest_framework_auth0/permissions.py
+++ b/rest_framework_auth0/permissions.py
@@ -1,12 +1,11 @@
 from __future__ import unicode_literals
 
 from rest_framework.permissions import BasePermission
+from rest_framework_auth0.authentication import Auth0JSONWebTokenAuthentication
+from rest_framework_auth0.utils import validate_role_from_payload
 
-from rest_framework_auth0.authentication import jwt_decode_handler
-from rest_framework_auth0.utils import get_jwt_value, validate_role_from_payload
 
-
-class HasRoleBasePermission(BasePermission):
+class HasRoleBasePermission(BasePermission, Auth0JSONWebTokenAuthentication):
     """
     Allows access only to users that have an specific role in their app_metadata
     attribute, app_metadata scope required
@@ -31,24 +30,20 @@ class HasRoleBasePermission(BasePermission):
     }
     """
 
-    role_name = ""
+    role_name = ''
 
     def get_role_name(self):
         return self.role_name
 
     def has_permission(self, request, view):
-
         if request.method == 'OPTIONS':
             return True
 
-        jwt = get_jwt_value(request)
+        payload = self.get_payload(request)
 
         try:
-            payload = jwt_decode_handler(jwt)
-
             return validate_role_from_payload(payload, self.get_role_name())
-
-        except Exception as e:
+        except Exception:
             return False
 
 

--- a/rest_framework_auth0/utils.py
+++ b/rest_framework_auth0/utils.py
@@ -1,5 +1,4 @@
 from rest_framework_auth0.settings import auth0_api_settings
-from rest_framework_auth0.authentication import JSONWebTokenAuthentication
 
 
 # Handlers --------------------------------------------------------------------
@@ -7,13 +6,6 @@ from rest_framework_auth0.authentication import JSONWebTokenAuthentication
 def auth0_get_username_from_payload_handler(payload):
     username = payload.get(auth0_api_settings.USERNAME_FIELD)
     return username
-
-
-# Authorization Utils ---------------------------------------------------------
-
-def get_jwt_value(request):
-    jwt_value = JSONWebTokenAuthentication().get_jwt_value(request)
-    return jwt_value
 
 
 # Auth0 Metadata --------------------------------------------------------------


### PR DESCRIPTION
To address #20, deleted `get_jwt_value`  on the `utils` module, to acomodate this, made `HasRoleBasePermission` inherit from `Auth0JSONWebTokenAuthentication`, so now it can use a new method on it called `get_payload`, which takes advantage JWT's `JSONWebTokenAuthentication.authenticate`, which in turn manages `jwt_decode_handler` errors and returns a validated `jwt_value` to retrive the payload. (`decorators` is more broken than ever now).