### PR TITLE
Optionally replace pipes for dots in auth0 username

### DIFF
--- a/rest_framework_auth0/authentication.py
+++ b/rest_framework_auth0/authentication.py
@@ -74,7 +74,11 @@ class Auth0JSONWebTokenAuthentication(JSONWebTokenAuthentication, RemoteUserBack
             # RemoteUserBackend behavior:
             # return
         user = None
-        username = self.clean_username(remote_user)
+
+        if auth0_api_settings.REPLACE_PIPE_FOR_DOTS_IN_USERNAME:
+            username = self.clean_username(remote_user)
+        else:
+            username = remote_user
 
         if self.create_unknown_user:
             user, created = UserModel._default_manager.get_or_create(**{

--- a/rest_framework_auth0/authentication.py
+++ b/rest_framework_auth0/authentication.py
@@ -74,7 +74,11 @@ class Auth0JSONWebTokenAuthentication(JSONWebTokenAuthentication, RemoteUserBack
             # RemoteUserBackend behavior:
             # return
         user = None
-        username = self.clean_username(remote_user)
+
+        if jwt_api_settings.REPLACE_PIPE_FOR_DOTS_IN_USERNAME:
+            username = self.clean_username(remote_user)
+        else:
+            username = remote_user
 
         if self.create_unknown_user:
             user, created = UserModel._default_manager.get_or_create(**{

--- a/rest_framework_auth0/settings.py
+++ b/rest_framework_auth0/settings.py
@@ -10,6 +10,7 @@ DEFAULTS = {
     'USERNAME_FIELD': 'sub',
     'CLIENT_CODE': 'Client_Code',
     'CLIENTS': {},
+    'REPLACE_PIPE_FOR_DOTS_IN_USERNAME': True,
     # Handlers
     'JWT_PAYLOAD_GET_USERNAME_HANDLER':
     'rest_framework_auth0.utils.auth0_get_username_from_payload_handler',


### PR DESCRIPTION
With the dot instead of the pipe, the usernames in my backend are inconsistent with the usernames in auth0, so if I need to change some user info in auth0 from my backend, I must replace again the dots for pipes. 

This can be configurable with the settings var REPLACE_PIPE_FOR_DOTS_IN_USERNAME, which is True by default. 