### PR TITLE
Return response when token is missing

### DIFF
--- a/rest_framework_auth0/decorators.py
+++ b/rest_framework_auth0/decorators.py
@@ -45,6 +45,8 @@ class token_required(object):
                 response = self.view_func(request, *args, **kwargs)
             else:
                 response = json_response({"msg":"Not valid token"}, status=401)
+        else:
+            response = json_response({"msg": "Missing token"}, status=401)
 
         # maybe do something after the view_func call
         # print ("----bye")


### PR DESCRIPTION
The decorator should return response in all cases. Case when
token was not provided at all was not handled and the code
was failing on "local variable 'response' referenced before
assignment"