### PR TITLE
fix: can't getattr when authentication try to clean name

### DIFF
--- a/rest_framework_auth0/settings.py
+++ b/rest_framework_auth0/settings.py
@@ -14,6 +14,7 @@ DEFAULTS = {
     # Handlers
     'JWT_PAYLOAD_GET_USERNAME_HANDLER':
     'rest_framework_auth0.utils.auth0_get_username_from_payload_handler',
+    'REPLACE_PIPE_FOR_DOTS_IN_USERNAME': False
 }
 
 # List of settings that may be in string import notation.


### PR DESCRIPTION
authentication.py  98
`
        if auth0_api_settings.REPLACE_PIPE_FOR_DOTS_IN_USERNAME:
`

the settings do not have the attr.